### PR TITLE
Rename Cart to Quote if it has quotable products and remove address fields

### DIFF
--- a/quotes-for-woocommerce/quotes-woocommerce.php
+++ b/quotes-for-woocommerce/quotes-woocommerce.php
@@ -74,6 +74,9 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
             
             // admin ajax 
             add_action( 'admin_init', array( &$this, 'qwc_ajax_admin' ) );
+
+            // Added to Cart messages.
+            add_filter( 'wc_add_to_cart_message', array( &$this, 'add_to_cart_message' ), 10, 2 );
         }
         
         /**
@@ -580,7 +583,23 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
     	    }
     	    die();
     	}
-    	
+
+        /**
+         * Change "Cart" to "Quote" after adding a quote-only product to the cart.
+         *
+         * @param string $message    Added to cart message HTML.
+         * @param int    $product_id Current product ID.
+         * @return string
+         */
+        public function add_to_cart_message( $message, $product_id ) {
+            if ( product_quote_enabled( $product_id ) ) {
+                $message = str_replace( 'added to your cart', 'added to your quote', $message );
+                $message = str_replace( 'View cart', 'View quote', $message );
+            }
+
+            return $message;
+        }
+
     } // end of class
 } 
 $quotes_for_wc = new quotes_for_wc();

--- a/quotes-for-woocommerce/quotes-woocommerce.php
+++ b/quotes-for-woocommerce/quotes-woocommerce.php
@@ -80,6 +80,13 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
 
             // Page titles.
             add_filter( 'the_title', array( &$this, 'woocommerce_title' ), 99, 2 );
+
+            // Disable shipping for quotes.
+            add_filter( 'woocommerce_cart_needs_shipping', array( &$this, 'cart_needs_shipping' ) );
+
+            // Disable address fields on checkout for quotes.
+            add_filter( 'woocommerce_billing_fields', array( &$this, 'billing_fields' ), 999 );
+            add_filter( 'woocommerce_checkout_fields', array( &$this, 'checkout_fields' ), 9999 );
         }
         
         /**
@@ -616,6 +623,61 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
             }
 
             return $title;
+        }
+
+        /**
+         * Disable shipping for quotes
+         *
+         * @param bool $needs_shipping Whether cart needs shipping or not.
+         * @return bool
+         */
+        public function cart_needs_shipping( $needs_shipping ) {
+            if ( cart_contains_quotable() ) {
+                return false;
+            } else {
+                return true;
+            }
+        }
+
+        /**
+         * Remove the billing fields if the cart is a quote.
+         *
+         * @param array $fields Billing fields.
+         * @return array
+         */
+        public function billing_fields( $fields = array() ) {
+            if ( cart_contains_quotable() ) {
+                unset( $fields['billing_company'] );
+                unset( $fields['billing_address_1'] );
+                unset( $fields['billing_address_2'] );
+                unset( $fields['billing_state'] );
+                unset( $fields['billing_city'] );
+                unset( $fields['billing_phone'] );
+                unset( $fields['billing_postcode'] );
+                unset( $fields['billing_country'] );
+            }
+
+            return $fields;
+        }
+
+        /**
+         * Remove the billing fields at checkout if the cart is a quote.
+         *
+         * @param array $fields Billing fields.
+         * @return array
+         */
+        public function checkout_fields( $fields ) {
+            if ( cart_contains_quotable() ) {
+                unset( $fields['billing']['billing_company'] );
+                unset( $fields['billing']['billing_country'] );
+                unset( $fields['billing']['billing_address_1'] );
+                unset( $fields['billing']['billing_address_2'] );
+                unset( $fields['billing']['billing_city'] );
+                unset( $fields['billing']['billing_state'] );
+                unset( $fields['billing']['billing_postcode'] );
+            }
+
+            return $fields;
         }
 
     } // end of class

--- a/quotes-for-woocommerce/quotes-woocommerce.php
+++ b/quotes-for-woocommerce/quotes-woocommerce.php
@@ -77,6 +77,9 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
 
             // Added to Cart messages.
             add_filter( 'wc_add_to_cart_message', array( &$this, 'add_to_cart_message' ), 10, 2 );
+
+            // Page titles.
+            add_filter( 'the_title', array( &$this, 'woocommerce_title' ), 99, 2 );
         }
         
         /**
@@ -598,6 +601,21 @@ if ( ! class_exists( 'quotes_for_wc' ) ) {
             }
 
             return $message;
+        }
+
+        /**
+         * Update the Cart title if is a quote
+         *
+         * @param string $title The post tile.
+         * @param int    $id    The post ID.
+         * @return string
+         */
+        public function woocommerce_title( $title,  $id ) {
+            if ( cart_contains_quotable() && $id === wc_get_page_id( 'cart' ) ) {
+                $title = __( 'Quote', 'quote-wc' );
+            }
+
+            return $title;
         }
 
     } // end of class


### PR DESCRIPTION
To make users know that they are submitting a quote request and not an actual purchase with a cart, I think it could be helpful to rename the **cart** page (and some strings) to **quote** if the product is a quote-only product or if the cart has quotable products.

Also, the address is not required the 100% of the times when it comes to quote requests, and some users will desist submitting all that info just for a quote. I added a function that checks if the cart has quotable products and if it does, removes the address fields. This one could be an option though, but I think it's a good idea.