### PR TITLE
Incorrect Order Totals

### DIFF
--- a/quotes-for-woocommerce/templates/emails/send-quote.php
+++ b/quotes-for-woocommerce/templates/emails/send-quote.php
@@ -127,7 +127,7 @@ if ( $order_obj ) :
 								echo 'border-top-width: 4px;';
 							}
 							?>
-							"><?php echo esc_attr( $total['value'] ); ?></td>
+							"><?php echo wp_kses_post( $total['value'] ); ?></td>
 						</tr>
 						<?php
 				}


### PR DESCRIPTION
The order totals in the send quote email appear with the HTML as
mentioned in
https://wordpress.org/support/topic/email-quote-sent-to-customer-shows-total-values-in-code-format/
&
https://wordpress.org/support/topic/format-problem-for-the-first-price-quote-email-sent/