### PR TITLE
WP Crash fix with some themes

### DIFF
--- a/quotes-for-woocommerce/class-quotes-wc.php
+++ b/quotes-for-woocommerce/class-quotes-wc.php
@@ -201,7 +201,6 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 		 */
 		public function qwc_include_files() {
 			include_once( WP_PLUGIN_DIR . '/quotes-for-woocommerce/includes/class-quotes-payment-gateway.php' );
-			include_once( WP_PLUGIN_DIR . '/quotes-for-woocommerce/includes/qwc-functions.php' );
 			include_once( WP_PLUGIN_DIR . '/quotes-for-woocommerce/includes/class-qwc-email-manager.php' );
 		}
 

--- a/quotes-for-woocommerce/quotes-woocommerce.php
+++ b/quotes-for-woocommerce/quotes-woocommerce.php
@@ -17,5 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! class_exists( 'Quotes_WC' ) ) {
+	include_once WP_PLUGIN_DIR . '/quotes-for-woocommerce/includes/qwc-functions.php';
 	include_once WP_PLUGIN_DIR . '/quotes-for-woocommerce/class-quotes-wc.php';
 }


### PR DESCRIPTION
Some users complaint that WC crashes after activating the plugin with certain themes such as Jevelin, Avada and so on.

https://wordpress.org/support/topic/wp-crash-after-activate/