### PR TITLE
Fixed: Internationalization + Header comment

### DIFF
--- a/quotes-for-woocommerce/class-quotes-wc.php
+++ b/quotes-for-woocommerce/class-quotes-wc.php
@@ -5,7 +5,7 @@
  * @package Quotes For WooCommerce
  */
 
-load_plugin_textdomain( 'quote-wc', false, basename( dirname( __FILE__ ) ) . '/languages' );
+load_plugin_textdomain( 'quotes-for-woocommerce', false, basename( dirname( __FILE__ ) ) . '/languages' );
 
 if ( ! class_exists( 'Quotes_WC' ) ) {
 
@@ -155,8 +155,8 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 				woocommerce_wp_checkbox(
 					array(
 						'id'          => 'qwc_enable_quotes',
-						'label'       => __( 'Enable Quotes', 'quote-wc' ),
-						'description' => __( 'Enable this to allow customers to ask for a quote for the product.', 'quote-wc' ),
+						'label'       => __( 'Enable Quotes', 'quotes-for-woocommerce' ),
+						'description' => __( 'Enable this to allow customers to ask for a quote for the product.', 'quotes-for-woocommerce' ),
 						'value'       => $quotes_checked,
 					)
 				);
@@ -167,8 +167,8 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 				woocommerce_wp_checkbox(
 					array(
 						'id'          => 'qwc_display_prices',
-						'label'       => __( 'Display Product Price', 'quote-wc' ),
-						'description' => __( 'Enable this to display the product price on the Shop & Product pages.', 'quote-wc' ),
+						'label'       => __( 'Display Product Price', 'quotes-for-woocommerce' ),
+						'description' => __( 'Enable this to display the product price on the Shop & Product pages.', 'quotes-for-woocommerce' ),
 						'value'       => $prices_enabled,
 					)
 				);
@@ -248,7 +248,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 			$enable_quote = product_quote_enabled( $post_id );
 
 			if ( $enable_quote ) {
-				$cart_text = '' === get_option( 'qwc_add_to_cart_button_text', '' ) ? esc_html__( 'Request Quote', 'quote-wc' ) : get_option( 'qwc_add_to_cart_button_text' );
+				$cart_text = '' === get_option( 'qwc_add_to_cart_button_text', '' ) ? esc_html__( 'Request Quote', 'quotes-for-woocommerce' ) : get_option( 'qwc_add_to_cart_button_text' );
 			}
 
 			return $cart_text;
@@ -360,7 +360,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 					array(
 						'ajax_url'  => $ajax_url,
 						'order_id'  => $post->ID,
-						'email_msg' => __( 'Quote emailed.', 'quote-wc' ),
+						'email_msg' => __( 'Quote emailed.', 'quotes-for-woocommerce' ),
 					)
 				);
 				wp_enqueue_script( 'qwc-admin' );
@@ -465,7 +465,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 					// Remove existing products.
 					WC()->cart->empty_cart();
 
-					wc_add_notice( __( 'It is not possible to add products that require quotes to the Cart along with ones that do not. Hence, the existing products have been removed from the Cart.', 'quote-wc' ), $notice_type = 'notice' );
+					wc_add_notice( __( 'It is not possible to add products that require quotes to the Cart along with ones that do not. Hence, the existing products have been removed from the Cart.', 'quotes-for-woocommerce' ), $notice_type = 'notice' );
 				}
 			}
 
@@ -612,13 +612,13 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 			if ( 'pending' === $order_status ) {
 				if ( 'quote-pending' === $quote_status ) {
 					?>
-					<button id='qwc_quote_complete' type="button" class="button"><?php esc_html_e( 'Quote Complete', 'quote-wc' ); ?></button>
+					<button id='qwc_quote_complete' type="button" class="button"><?php esc_html_e( 'Quote Complete', 'quotes-for-woocommerce' ); ?></button>
 					<?php
 				} else {
 					if ( 'quote-complete' === $quote_status ) {
-						$button_text = esc_html__( 'Send Quote', 'quote-wc' );
+						$button_text = esc_html__( 'Send Quote', 'quotes-for-woocommerce' );
 					} elseif ( 'quote-sent' === $quote_status ) {
-						$button_text = esc_html__( 'Resend Quote', 'quote-wc' );
+						$button_text = esc_html__( 'Resend Quote', 'quotes-for-woocommerce' );
 					}
 					?>
 					<button id='qwc_send_quote' type="button" class="button"><?php echo esc_html( $button_text ); ?></button>
@@ -643,7 +643,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 
 			// Add order note that quote has been completed.
 			$order = new WC_Order( $order_id );
-			$order->add_order_note( __( 'Quote Complete.', 'quote-wc' ) );
+			$order->add_order_note( __( 'Quote Complete.', 'quotes-for-woocommerce' ) );
 			die();
 		}
 
@@ -697,7 +697,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 		public function qwc_admin_menu() {
 
 			add_menu_page( 'Quotes', 'Quotes', 'manage_woocommerce', 'qwc_settings', array( &$this, 'qwc_settings' ) );
-			$page = add_submenu_page( 'qwc_settings', __( 'Settings', 'quote-wc' ), __( 'Settings', 'quote-wc' ), 'manage_woocommerce', 'quote_settings', array( &$this, 'qwc_settings' ) );
+			$page = add_submenu_page( 'qwc_settings', __( 'Settings', 'quotes-for-woocommerce' ), __( 'Settings', 'quotes-for-woocommerce' ), 'manage_woocommerce', 'quote_settings', array( &$this, 'qwc_settings' ) );
 			remove_submenu_page( 'qwc_settings', 'qwc_settings' );
 
 		}
@@ -713,7 +713,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 				global $wpdb;
 				// Check the user capabilities.
 				if ( ! current_user_can( 'manage_woocommerce' ) ) {
-					wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'quote-wc' ) );
+					wp_die( esc_html__( 'You do not have sufficient permissions to access this page.', 'quotes-for-woocommerce' ) );
 				}
 
 				?>
@@ -748,7 +748,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 		 */
 		public function add_to_cart_message( $message, $products ) {
 			$cart_name = get_option( 'qwc_cart_page_name', '' );
-			$cart_name = '' === $cart_name ? __( 'Cart', 'quote-wc' ) : $cart_name;
+			$cart_name = '' === $cart_name ? __( 'Cart', 'quotes-for-woocommerce' ) : $cart_name;
 
 			if ( is_array( $products ) && count( $products ) > 0 ) {
 				foreach ( $products as $product_id => $value ) {
@@ -776,7 +776,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 				$cart_name = get_option( 'qwc_cart_page_name' );
 				$cart_name = '' === $cart_name ? 'Cart' : $cart_name; //phpcs:ignore
 
-				$title = esc_attr__( $cart_name, 'quote-wc' ); //phpcs:ignore
+				$title = esc_attr__( $cart_name, 'quotes-for-woocommerce' ); //phpcs:ignore
 			}
 
 			return $title;
@@ -848,7 +848,7 @@ if ( ! class_exists( 'Quotes_WC' ) ) {
 		 */
 		public static function qwc_plugin_settings_link( $links ) {
 			$settings_link = array(
-				'settings' => '<a href="admin.php?page=quote_settings">' . __( 'Settings', 'quote-wc' ) . '</a>',
+				'settings' => '<a href="admin.php?page=quote_settings">' . __( 'Settings', 'quotes-for-woocommerce' ) . '</a>',
 			);
 			return array_merge( $settings_link, $links );
 		}

--- a/quotes-for-woocommerce/includes/admin/class-quotes-global-settings.php
+++ b/quotes-for-woocommerce/includes/admin/class-quotes-global-settings.php
@@ -37,77 +37,77 @@ if ( ! class_exists( 'Quotes_Global_Settings' ) ) {
 			// First, we register a section. This is necessary since all future options must belong to a section.
 			add_settings_section(
 				'qwc_general_settings_section',                    // ID used to identify this section and with which to register options.
-				__( 'Global Settings', 'quote-wc' ),                      // Title to be displayed on the administration page.
+				__( 'Global Settings', 'quotes-for-woocommerce' ),                      // Title to be displayed on the administration page.
 				array( $this, 'qwc_general_options_callback' ),    // Callback used to render the description of the section.
 				'qwc_bulk_page'                                         // Page on which to add this section of options.
 			);
 
 			add_settings_field(
 				'qwc_enable_global_quote',
-				__( 'Enable Quotes:', 'quote-wc' ),
+				__( 'Enable Quotes:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_enable_global_quote_callback' ),
 				'qwc_bulk_page',
 				'qwc_general_settings_section',
-				array( __( 'Select if you wish to enable quotes for all the products.', 'quote-wc' ) )
+				array( __( 'Select if you wish to enable quotes for all the products.', 'quotes-for-woocommerce' ) )
 			);
 
 			add_settings_field(
 				'qwc_enable_global_prices',
-				__( 'Enable Price Display:', 'quote-wc' ),
+				__( 'Enable Price Display:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_enable_global_price_callback' ),
 				'qwc_bulk_page',
 				'qwc_general_settings_section',
-				array( __( 'Select to display the product price on the Shop & Product pages for all quotable products.', 'quote-wc' ) )
+				array( __( 'Select to display the product price on the Shop & Product pages for all quotable products.', 'quotes-for-woocommerce' ) )
 			);
 
 			add_settings_section(
 				'qwc_shop_product_settings_section',                    // ID used to identify this section and with which to register options.
-				__( 'Shop & Product Page Settings', 'quote-wc' ),   // Title to be displayed on the administration page.
+				__( 'Shop & Product Page Settings', 'quotes-for-woocommerce' ),   // Title to be displayed on the administration page.
 				array( $this, 'qwc_shop_product_settings_callback' ),    // Callback used to render the description of the section.
 				'qwc_page'                                         // Page on which to add this section of options.
 			);
 
 			add_settings_field(
 				'qwc_add_to_cart_button_text',
-				__( 'Add to Cart button text:', 'quote-wc' ),
+				__( 'Add to Cart button text:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_add_to_cart_button_text_callback' ),
 				'qwc_page',
 				'qwc_shop_product_settings_section',
-				array( __( 'Text that should be displayed on the Add to Cart button for quotable products.', 'quote-wc' ) )
+				array( __( 'Text that should be displayed on the Add to Cart button for quotable products.', 'quotes-for-woocommerce' ) )
 			);
 
 			add_settings_section(
 				'qwc_cart_settings_section',                    // ID used to identify this section and with which to register options.
-				__( 'Cart & Checkout Settings', 'quote-wc' ),   // Title to be displayed on the administration page.
+				__( 'Cart & Checkout Settings', 'quotes-for-woocommerce' ),   // Title to be displayed on the administration page.
 				array( $this, 'qwc_cart_settings_callback' ),   // Callback used to render the description of the section.
 				'qwc_page'                                      // Page on which to add this section of options.
 			);
 
 			add_settings_field(
 				'qwc_place_order_text',
-				__( 'Place Order button text for Quotable Products:', 'quote-wc' ),
+				__( 'Place Order button text for Quotable Products:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_place_order_text_callback' ),
 				'qwc_page',
 				'qwc_cart_settings_section',
-				array( __( 'Place Order button text for Quotable products at Checkout.', 'quote-wc' ) )
+				array( __( 'Place Order button text for Quotable products at Checkout.', 'quotes-for-woocommerce' ) )
 			);
 
 			add_settings_field(
 				'qwc_cart_page_name',
-				__( 'Cart page Name for Quotable Products:', 'quote-wc' ),
+				__( 'Cart page Name for Quotable Products:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_cart_page_name_callback' ),
 				'qwc_page',
 				'qwc_cart_settings_section',
-				array( __( 'Display a custom name for Cart page when cart contains only quotable products.', 'quote-wc' ) )
+				array( __( 'Display a custom name for Cart page when cart contains only quotable products.', 'quotes-for-woocommerce' ) )
 			);
 
 			add_settings_field(
 				'qwc_hide_address_fields',
-				__( 'Hide Address fields at Checkout:', 'quote-wc' ),
+				__( 'Hide Address fields at Checkout:', 'quotes-for-woocommerce' ),
 				array( $this, 'qwc_hide_address_fields_callback' ),
 				'qwc_page',
 				'qwc_cart_settings_section',
-				array( __( 'Hide Billing & Shipping Address fields at Checkout if the Cart contains only quotable products.', 'quote-wc' ) )
+				array( __( 'Hide Billing & Shipping Address fields at Checkout if the Cart contains only quotable products.', 'quotes-for-woocommerce' ) )
 			);
 
 			register_setting(
@@ -236,7 +236,7 @@ if ( ! class_exists( 'Quotes_Global_Settings' ) ) {
 
 			$add_to_cart_button_text = get_option( 'qwc_add_to_cart_button_text', '' );
 
-			$add_to_cart_button_text = '' === $add_to_cart_button_text ? esc_html__( 'Request Quote', 'quote-wc' ) : $add_to_cart_button_text;
+			$add_to_cart_button_text = '' === $add_to_cart_button_text ? esc_html__( 'Request Quote', 'quotes-for-woocommerce' ) : $add_to_cart_button_text;
 
 			echo sprintf(
 				'<input type="text" id="qwc_add_to_cart_button_text" name="qwc_add_to_cart_button_text" value="%s" />',
@@ -263,7 +263,7 @@ if ( ! class_exists( 'Quotes_Global_Settings' ) ) {
 			$cart_page_name = get_option( 'qwc_cart_page_name', '' );
 
 			if ( '' === $cart_page_name ) {
-				$cart_page_name = esc_html__( 'Cart', 'quote-wc' );
+				$cart_page_name = esc_html__( 'Cart', 'quotes-for-woocommerce' );
 			}
 			echo sprintf(
 				'<input type="text" id="qwc_cart_page_name" name="qwc_cart_page_name" value="%s" />',
@@ -283,7 +283,7 @@ if ( ! class_exists( 'Quotes_Global_Settings' ) ) {
 			$place_order_button_text = get_option( 'qwc_place_order_text', '' );
 
 			if ( '' === $place_order_button_text ) {
-				$place_order_button_text = esc_html__( 'Request Quote', 'quote-wc' );
+				$place_order_button_text = esc_html__( 'Request Quote', 'quotes-for-woocommerce' );
 			}
 			echo sprintf(
 				'<input type="text" id="qwc_place_order_text" name="qwc_place_order_text" value="%s" />',

--- a/quotes-for-woocommerce/includes/class-quotes-payment-gateway.php
+++ b/quotes-for-woocommerce/includes/class-quotes-payment-gateway.php
@@ -24,9 +24,9 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			$this->id                = 'quotes-gateway';
 			$this->icon              = '';
 			$this->has_fields        = false;
-			$this->method_title      = __( 'Ask for Quote', 'quote-wc' );
+			$this->method_title      = __( 'Ask for Quote', 'quotes-for-woocommerce' );
 			$this->title             = $this->method_title;
-			$this->order_button_text = '' === get_option( 'qwc_place_order_text', '' ) ? __( 'Request Quote', 'quote-wc' ) : get_option( 'qwc_place_order_text' );
+			$this->order_button_text = '' === get_option( 'qwc_place_order_text', '' ) ? __( 'Request Quote', 'quotes-for-woocommerce' ) : get_option( 'qwc_place_order_text' );
 
 			// Actions.
 			add_action( 'woocommerce_thankyou_' . $this->id, array( $this, 'thankyou_page' ) );
@@ -36,12 +36,12 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 		 * Admin Settings.
 		 */
 		public function admin_options() {
-			$title = ( ! empty( $this->method_title ) ) ? $this->method_title : esc_html__( 'Settings', 'quote-wc' );
+			$title = ( ! empty( $this->method_title ) ) ? $this->method_title : esc_html__( 'Settings', 'quotes-for-woocommerce' );
 
 			echo '<h3>' . esc_attr( $title ) . '</h3>';
 
-			echo '<p>' . esc_html__( 'This is fictitious payment method used for quotes.', 'quote-wc' ) . '</p>';
-			echo '<p>' . esc_html__( 'This gateway requires no configuration.', 'quote-wc' ) . '</p>';
+			echo '<p>' . esc_html__( 'This is fictitious payment method used for quotes.', 'quotes-for-woocommerce' ) . '</p>';
+			echo '<p>' . esc_html__( 'This gateway requires no configuration.', 'quotes-for-woocommerce' ) . '</p>';
 
 			// Hides the save button.
 			echo '<style>p.submit input[type="submit"] { display: none }</style>';
@@ -61,7 +61,7 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			update_post_meta( $order_id, '_qwc_quote', '1' );
 
 			// Add custom order note.
-			$order->add_order_note( esc_html__( 'This order is awaiting quote.', 'quote-wc' ) );
+			$order->add_order_note( esc_html__( 'This order is awaiting quote.', 'quotes-for-woocommerce' ) );
 
 			// Remove cart.
 			WC()->cart->empty_cart();
@@ -82,9 +82,9 @@ if ( class_exists( 'WC_Payment_Gateway' ) ) {
 			$order = new WC_Order( $order_id );
 
 			if ( 'completed' === $order->get_status() ) {
-				echo '<p>' . esc_html__( 'We have received your order. Thank you.', 'quote-wc' ) . '</p>';
+				echo '<p>' . esc_html__( 'We have received your order. Thank you.', 'quotes-for-woocommerce' ) . '</p>';
 			} else {
-				echo '<p>' . esc_html__( 'We have received your request for a quote. You will be notified via email soon.', 'quote-wc' ) . '</p>';
+				echo '<p>' . esc_html__( 'We have received your request for a quote. You will be notified via email soon.', 'quotes-for-woocommerce' ) . '</p>';
 			}
 		}
 

--- a/quotes-for-woocommerce/includes/emails/class-qwc-request-new-quote.php
+++ b/quotes-for-woocommerce/includes/emails/class-qwc-request-new-quote.php
@@ -20,11 +20,11 @@ class QWC_Request_New_Quote extends WC_Email {
 	public function __construct() {
 
 		$this->id          = 'qwc_req_new_quote';
-		$this->title       = __( 'Request for New Quote', 'quote-wc' );
-		$this->description = __( 'This email is sent to the site admin when a request for a quotation comes through.', 'quote-wc' );
+		$this->title       = __( 'Request for New Quote', 'quotes-for-woocommerce' );
+		$this->description = __( 'This email is sent to the site admin when a request for a quotation comes through.', 'quotes-for-woocommerce' );
 
-		$this->heading = __( 'Quotation Request for #{order_number}', 'quote-wc' );
-		$this->subject = __( '[{blogname}] Quotation Request (Order {order_number}) - {order_date}', 'quote-wc' );
+		$this->heading = __( 'Quotation Request for #{order_number}', 'quotes-for-woocommerce' );
+		$this->subject = __( '[{blogname}] Quotation Request (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 
 		$this->template_html  = 'emails/request-new-quote.php';
 		$this->template_plain = 'emails/plain/request-new-quote.php';
@@ -91,19 +91,19 @@ class QWC_Request_New_Quote extends WC_Email {
 					$this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->item_hidden_date ) );
 
 					$this->find[]    = '{order_number}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 
 					$this->find[]    = '{billing_first_name}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 
 					$this->find[]    = '{billing_last_name}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 
 					$this->find[]    = '{billing_email}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 
 					$this->find[]    = '{billing_phone}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 				}
 
 				$this->find[]    = '{blogname}';
@@ -202,7 +202,7 @@ class QWC_Request_New_Quote extends WC_Email {
 	 * Default Email Subject.
 	 */
 	public function get_default_subject() {
-		return __( '[{blogname}] Quotation Request (Order {order_number}) - {order_date}', 'quote-wc' );
+		return __( '[{blogname}] Quotation Request (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 
 	}
 
@@ -210,7 +210,7 @@ class QWC_Request_New_Quote extends WC_Email {
 	 * Default Email Heading.
 	 */
 	public function get_default_heading() {
-		return __( 'Quotation Request for #{order_number}', 'quote-wc' );
+		return __( 'Quotation Request for #{order_number}', 'quotes-for-woocommerce' );
 	}
 
 	/**
@@ -219,44 +219,44 @@ class QWC_Request_New_Quote extends WC_Email {
 	public function init_form_fields() {
 		$this->form_fields = array(
 			'enabled'    => array(
-				'title'   => __( 'Enable/Disable', 'quote-wc' ),
+				'title'   => __( 'Enable/Disable', 'quotes-for-woocommerce' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable this email notification', 'quote-wc' ),
+				'label'   => __( 'Enable this email notification', 'quotes-for-woocommerce' ),
 				'default' => 'yes',
 			),
 			'recipient'  => array(
-				'title'       => __( 'Recipient', 'quote-wc' ),
+				'title'       => __( 'Recipient', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email recipients.
-				'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s', 'quote-wc' ), get_option( 'admin_email' ) ),
+				'description' => sprintf( __( 'Enter recipients (comma separated) for this email. Defaults to %s', 'quotes-for-woocommerce' ), get_option( 'admin_email' ) ),
 				'default'     => get_option( 'admin_email' ),
 			),
 			'subject'    => array(
-				'title'       => __( 'Subject', 'quote-wc' ),
+				'title'       => __( 'Subject', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Subject.
-				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quote-wc' ), $this->subject ),
+				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->subject ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'heading'    => array(
-				'title'       => __( 'Email Heading', 'quote-wc' ),
+				'title'       => __( 'Email Heading', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Heading.
-				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quote-wc' ), $this->heading ),
+				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->heading ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'email_type' => array(
-				'title'       => __( 'Email type', 'quote-wc' ),
+				'title'       => __( 'Email type', 'quotes-for-woocommerce' ),
 				'type'        => 'select',
-				'description' => __( 'Choose which format of email to send.', 'quote-wc' ),
+				'description' => __( 'Choose which format of email to send.', 'quotes-for-woocommerce' ),
 				'default'     => 'html',
 				'class'       => 'email_type',
 				'options'     => array(
-					'plain'     => __( 'Plain text', 'quote-wc' ),
-					'html'      => __( 'HTML', 'quote-wc' ),
-					'multipart' => __( 'Multipart', 'quote-wc' ),
+					'plain'     => __( 'Plain text', 'quotes-for-woocommerce' ),
+					'html'      => __( 'HTML', 'quotes-for-woocommerce' ),
+					'multipart' => __( 'Multipart', 'quotes-for-woocommerce' ),
 				),
 			),
 		);

--- a/quotes-for-woocommerce/includes/emails/class-qwc-request-sent.php
+++ b/quotes-for-woocommerce/includes/emails/class-qwc-request-sent.php
@@ -21,11 +21,11 @@ class QWC_Request_Sent extends WC_Email {
 	public function __construct() {
 
 		$this->id          = 'qwc_request_sent';
-		$this->title       = __( 'New Quote Request Sent', 'quote-wc' );
-		$this->description = __( 'This email is sent to the customer when a quote request is raised', 'quote-wc' );
+		$this->title       = __( 'New Quote Request Sent', 'quotes-for-woocommerce' );
+		$this->description = __( 'This email is sent to the customer when a quote request is raised', 'quotes-for-woocommerce' );
 
-		$this->heading = __( 'Quotation Request Sent for #{order_number}', 'quote-wc' );
-		$this->subject = __( '[{blogname}] Quotation Request Sent (Order {order_number}) - {order_date}', 'quote-wc' );
+		$this->heading = __( 'Quotation Request Sent for #{order_number}', 'quotes-for-woocommerce' );
+		$this->subject = __( '[{blogname}] Quotation Request Sent (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 
 		$this->template_html  = 'emails/new-request-sent-customer.php';
 		$this->template_plain = 'emails/plain/new-request-sent-customer.php';
@@ -80,7 +80,7 @@ class QWC_Request_Sent extends WC_Email {
 					$this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->item_hidden_date ) );
 
 					$this->find[]    = '{order_number}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 				}
 
 				$this->find[]    = '{blogname}';
@@ -172,14 +172,14 @@ class QWC_Request_Sent extends WC_Email {
 	 * Default Email Subject.
 	 */
 	public function get_default_subject() {
-		return __( '[{blogname}] Quotation Request Sent (Order {order_number}) - {order_date}', 'quote-wc' );
+		return __( '[{blogname}] Quotation Request Sent (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 	}
 
 	/**
 	 * Default Email Heading.
 	 */
 	public function get_default_heading() {
-		return __( 'Quotation Request Sent for #{order_number}', 'quote-wc' );
+		return __( 'Quotation Request Sent for #{order_number}', 'quotes-for-woocommerce' );
 	}
 
 	/**
@@ -188,37 +188,37 @@ class QWC_Request_Sent extends WC_Email {
 	public function init_form_fields() {
 		$this->form_fields = array(
 			'enabled'    => array(
-				'title'   => __( 'Enable/Disable', 'quote-wc' ),
+				'title'   => __( 'Enable/Disable', 'quotes-for-woocommerce' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable this email notification', 'quote-wc' ),
+				'label'   => __( 'Enable this email notification', 'quotes-for-woocommerce' ),
 				'default' => 'yes',
 			),
 			'subject'    => array(
-				'title'       => __( 'Subject', 'quote-wc' ),
+				'title'       => __( 'Subject', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Subject.
-				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quote-wc' ), $this->subject ),
+				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->subject ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'heading'    => array(
-				'title'       => __( 'Email Heading', 'quote-wc' ),
+				'title'       => __( 'Email Heading', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Heading.
-				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quote-wc' ), $this->heading ),
+				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->heading ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'email_type' => array(
-				'title'       => __( 'Email type', 'quote-wc' ),
+				'title'       => __( 'Email type', 'quotes-for-woocommerce' ),
 				'type'        => 'select',
-				'description' => __( 'Choose which format of email to send.', 'quote-wc' ),
+				'description' => __( 'Choose which format of email to send.', 'quotes-for-woocommerce' ),
 				'default'     => 'html',
 				'class'       => 'email_type',
 				'options'     => array(
-					'plain'     => __( 'Plain text', 'quote-wc' ),
-					'html'      => __( 'HTML', 'quote-wc' ),
-					'multipart' => __( 'Multipart', 'quote-wc' ),
+					'plain'     => __( 'Plain text', 'quotes-for-woocommerce' ),
+					'html'      => __( 'HTML', 'quotes-for-woocommerce' ),
+					'multipart' => __( 'Multipart', 'quotes-for-woocommerce' ),
 				),
 			),
 		);

--- a/quotes-for-woocommerce/includes/emails/class-qwc-send-quote.php
+++ b/quotes-for-woocommerce/includes/emails/class-qwc-send-quote.php
@@ -20,11 +20,11 @@ class QWC_Send_Quote extends WC_Email {
 	public function __construct() {
 
 		$this->id          = 'qwc_send_quote';
-		$this->title       = __( 'Send Quote', 'quote-wc' );
-		$this->description = __( 'This email is sent to Customers for orders that need quotations.', 'quote-wc' );
+		$this->title       = __( 'Send Quote', 'quotes-for-woocommerce' );
+		$this->description = __( 'This email is sent to Customers for orders that need quotations.', 'quotes-for-woocommerce' );
 
-		$this->heading = __( 'Quote for #{order_number}', 'quote-wc' );
-		$this->subject = __( '[{blogname}] Quotation for (Order {order_number}) - {order_date}', 'quote-wc' );
+		$this->heading = __( 'Quote for #{order_number}', 'quotes-for-woocommerce' );
+		$this->subject = __( '[{blogname}] Quotation for (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 
 		$this->template_html  = 'emails/send-quote.php';
 		$this->template_plain = 'emails/plain/send-quote.php';
@@ -80,7 +80,7 @@ class QWC_Send_Quote extends WC_Email {
 					$this->replace[] = date_i18n( wc_date_format(), strtotime( $this->object->item_hidden_date ) );
 
 					$this->find[]    = '{order_number}';
-					$this->replace[] = __( 'N/A', 'quote-wc' );
+					$this->replace[] = __( 'N/A', 'quotes-for-woocommerce' );
 				}
 
 				$this->find[]    = '{blogname}';
@@ -170,14 +170,14 @@ class QWC_Send_Quote extends WC_Email {
 	 * Default Email Subject.
 	 */
 	public function get_default_subject() {
-		return __( '[{blogname}] Quotation for (Order {order_number}) - {order_date}', 'quote-wc' );
+		return __( '[{blogname}] Quotation for (Order {order_number}) - {order_date}', 'quotes-for-woocommerce' );
 	}
 
 	/**
 	 * Default Email Heading.
 	 */
 	public function get_default_heading() {
-		return __( 'Quote for #{order_number}', 'quote-wc' );
+		return __( 'Quote for #{order_number}', 'quotes-for-woocommerce' );
 	}
 
 	/**
@@ -186,37 +186,37 @@ class QWC_Send_Quote extends WC_Email {
 	public function init_form_fields() {
 		$this->form_fields = array(
 			'enabled'    => array(
-				'title'   => __( 'Enable/Disable', 'quote-wc' ),
+				'title'   => __( 'Enable/Disable', 'quotes-for-woocommerce' ),
 				'type'    => 'checkbox',
-				'label'   => __( 'Enable this email notification', 'quote-wc' ),
+				'label'   => __( 'Enable this email notification', 'quotes-for-woocommerce' ),
 				'default' => 'yes',
 			),
 			'subject'    => array(
-				'title'       => __( 'Subject', 'quote-wc' ),
+				'title'       => __( 'Subject', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Subject.
-				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quote-wc' ), $this->subject ),
+				'description' => sprintf( __( 'This controls the email subject line. Leave blank to use the default subject: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->subject ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'heading'    => array(
-				'title'       => __( 'Email Heading', 'quote-wc' ),
+				'title'       => __( 'Email Heading', 'quotes-for-woocommerce' ),
 				'type'        => 'text',
 				// translators: Email Heading.
-				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quote-wc' ), $this->heading ),
+				'description' => sprintf( __( 'This controls the main heading contained within the email notification. Leave blank to use the default heading: <code>%s</code>.', 'quotes-for-woocommerce' ), $this->heading ),
 				'placeholder' => '',
 				'default'     => '',
 			),
 			'email_type' => array(
-				'title'       => __( 'Email type', 'quote-wc' ),
+				'title'       => __( 'Email type', 'quotes-for-woocommerce' ),
 				'type'        => 'select',
-				'description' => __( 'Choose which format of email to send.', 'quote-wc' ),
+				'description' => __( 'Choose which format of email to send.', 'quotes-for-woocommerce' ),
 				'default'     => 'html',
 				'class'       => 'email_type',
 				'options'     => array(
-					'plain'     => __( 'Plain text', 'quote-wc' ),
-					'html'      => __( 'HTML', 'quote-wc' ),
-					'multipart' => __( 'Multipart', 'quote-wc' ),
+					'plain'     => __( 'Plain text', 'quotes-for-woocommerce' ),
+					'html'      => __( 'HTML', 'quotes-for-woocommerce' ),
+					'multipart' => __( 'Multipart', 'quotes-for-woocommerce' ),
 				),
 			),
 		);

--- a/quotes-for-woocommerce/languages/quotes-for-woocommerce.pot
+++ b/quotes-for-woocommerce/languages/quotes-for-woocommerce.pot
@@ -2,17 +2,17 @@
 # This file is distributed under the same license as the Quotes for WooCommerce plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Quotes for WooCommerce 1.6.4\n"
+"Project-Id-Version: Quotes for WooCommerce 1.7.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/quotes-for-woocommerce\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2020-06-20T16:37:48+00:00\n"
+"POT-Creation-Date: 2020-06-27T01:21:39-04:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
-"X-Domain: quote-wc\n"
+"X-Generator: WP-CLI 2.3.0\n"
+"X-Domain: quotes-for-woocommerce\n"
 
 #. Plugin Name of the plugin
 msgid "Quotes for WooCommerce"

--- a/quotes-for-woocommerce/quotes-woocommerce.php
+++ b/quotes-for-woocommerce/quotes-woocommerce.php
@@ -4,10 +4,13 @@
  * Description: This plugin allows you to convert your WooCommerce store into a quote only store. It will hide the prices for the products and not take any payment at Checkout. You can then setup prices for the items in the order and send a notification to the Customer.
  * Version: 1.7.0
  * Author: Pinal Shah
- * WC Requires at least: 3.0.0
- * WC tested up to: 4.2.0
- * Text Domain: quote-wc
+ * Requires at least: 4.5
+ * WC Requires at least: 3.0
+ * WC tested up to: 4.2
+ * Text Domain: quotes-for-woocommerce
  * Domain Path: /languages/
+ * License: GPL v2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.txt
  *
  * @package Quotes For WooCommerce
  */

--- a/quotes-for-woocommerce/readme.txt
+++ b/quotes-for-woocommerce/readme.txt
@@ -3,9 +3,10 @@
 Contributors: pinal.shah
 Tags: woocommerce, quotes, proposals, hide-price, request-a-quote, woocommerce-request-quote
 Requires at least: 4.5
-Tested up to: 5.4.2
+Tested up to: 5.4
 Stable tag: 1.7.0
-License: GPLv2 or later
+License: GPL v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.txt
 
 This WordPress plugin extends the WooCommerce Plugin. It allows the site admin the ability to send quotes for products. All prices are hidden from the user on all pages until the admin sends a quote. No payments will be taken at Checkout. 
 

--- a/quotes-for-woocommerce/templates/emails/new-request-sent-customer.php
+++ b/quotes-for-woocommerce/templates/emails/new-request-sent-customer.php
@@ -9,7 +9,7 @@ $order_obj     = new WC_order( $order->order_id );
 $display_price = false;
 
 // translators: Site Name.
-$opening_paragraph = __( 'You have made a request for a quote on %s. The details of the order are as follows:', 'quote-wc' );
+$opening_paragraph = __( 'You have made a request for a quote on %s. The details of the order are as follows:', 'quotes-for-woocommerce' );
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
@@ -23,13 +23,13 @@ if ( $order ) :
 <table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
 	<tbody>
 		<tr>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quote-wc' ); ?></th>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quote-wc' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quotes-for-woocommerce' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quotes-for-woocommerce' ); ?></th>
 			<?php
 			if ( qwc_order_display_price( $order_obj ) ) {
 				$display_price = true;
 				?>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product Price', 'quote-wc' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product Price', 'quotes-for-woocommerce' ); ?></th>
 			<?php } ?>
 
 		</tr>
@@ -49,8 +49,8 @@ if ( $order ) :
 	</tbody>
 </table>
 
-<p><?php esc_html_e( 'This order is awaiting a quote.', 'quote-wc' ); ?></p>
+<p><?php esc_html_e( 'This order is awaiting a quote.', 'quotes-for-woocommerce' ); ?></p>
 
-<p><?php esc_html_e( 'You shall receive a quote email from the site admin soon.', 'quote-wc' ); ?></p>
+<p><?php esc_html_e( 'You shall receive a quote email from the site admin soon.', 'quotes-for-woocommerce' ); ?></p>
 
 <?php do_action( 'woocommerce_email_footer' ); ?>

--- a/quotes-for-woocommerce/templates/emails/plain/new-request-sent-customer.php
+++ b/quotes-for-woocommerce/templates/emails/plain/new-request-sent-customer.php
@@ -4,7 +4,7 @@
  */
 $order_obj = new WC_order( $order->order_id );
 $display_price = false;
-$opening_paragraph = __( 'You have made a request for a quote on %s. The details of the order are as follows:', 'quote-wc' );
+$opening_paragraph = __( 'You have made a request for a quote on %s. The details of the order are as follows:', 'quotes-for-woocommerce' );
 
 do_action( 'woocommerce_email_header', $email_heading );
 
@@ -13,11 +13,11 @@ if( $order ) {
 }
 
 if ( $order_obj ) {
-    echo sprintf( __( 'Product', 'quote-wc' ) );
-    echo sprintf( __( 'Quantity', 'quote-wc' ) );
+    echo sprintf( __( 'Product', 'quotes-for-woocommerce' ) );
+    echo sprintf( __( 'Quantity', 'quotes-for-woocommerce' ) );
     if( qwc_order_display_price( $order_obj ) ) {
         $display_price = true;
-        echo sprintf( __( 'Product Price', 'quote-wc' ) );
+        echo sprintf( __( 'Product Price', 'quotes-for-woocommerce' ) );
     }
     
     echo "\n";
@@ -33,9 +33,9 @@ if ( $order_obj ) {
             
 	} 
 	
-    echo sprintf( __( 'This order is awaiting a quote.', 'quote-wc' ) );
+    echo sprintf( __( 'This order is awaiting a quote.', 'quotes-for-woocommerce' ) );
     
-    echo sprintf( __( 'You shall receive a quote email from the site admin soon.', 'quote-wc' ) );
+    echo sprintf( __( 'You shall receive a quote email from the site admin soon.', 'quotes-for-woocommerce' ) );
     
     do_action( 'woocommerce_email_footer' );
 }

--- a/quotes-for-woocommerce/templates/emails/plain/request-new-quote.php.php
+++ b/quotes-for-woocommerce/templates/emails/plain/request-new-quote.php.php
@@ -4,7 +4,7 @@
  */
 $order_obj = new WC_order( $order->order_id );
 
-$opening_paragraph = __( 'A request for quote has been made by %s and is awaiting your attention. The details of the order are as follows:', 'quote-wc' );
+$opening_paragraph = __( 'A request for quote has been made by %s and is awaiting your attention. The details of the order are as follows:', 'quotes-for-woocommerce' );
 
 do_action( 'woocommerce_email_header', $email_heading );
 
@@ -15,9 +15,9 @@ if ( $order_obj && $billing_first_name && $billing_last_name ) :
 endif;
 
 if ( $order_obj ) {
-    echo sprintf( __( 'Product', 'quote-wc' ) );
-    echo sprintf( __( 'Quantity', 'quote-wc' ) );
-    echo sprintf( __( 'Product Price', 'quote-wc' ) );
+    echo sprintf( __( 'Product', 'quotes-for-woocommerce' ) );
+    echo sprintf( __( 'Quantity', 'quotes-for-woocommerce' ) );
+    echo sprintf( __( 'Product Price', 'quotes-for-woocommerce' ) );
 
     echo "\n";
 			
@@ -30,9 +30,9 @@ if ( $order_obj ) {
             
 	} 
 	
-    echo sprintf( __( 'This order is awaiting a quote.', 'quote-wc' ) );
+    echo sprintf( __( 'This order is awaiting a quote.', 'quotes-for-woocommerce' ) );
     
-    echo make_clickable( sprintf( __( 'You can view and edit this order in the dashboard here: %s', 'quote-wc' ), admin_url( 'post.php?post=' . $order->order_id . '&action=edit' ) ) );
+    echo make_clickable( sprintf( __( 'You can view and edit this order in the dashboard here: %s', 'quotes-for-woocommerce' ), admin_url( 'post.php?post=' . $order->order_id . '&action=edit' ) ) );
     
     do_action( 'woocommerce_email_footer' );
 }

--- a/quotes-for-woocommerce/templates/emails/plain/send-quote.php
+++ b/quotes-for-woocommerce/templates/emails/plain/send-quote.php
@@ -8,16 +8,16 @@ do_action( 'woocommerce_email_header', $email_heading );
 $order_obj = new WC_order( $order->order_id );
 if ( $order ) : 
     $billing_first_name = ( version_compare( WOOCOMMERCE_VERSION, "3.0.0" ) < 0 ) ? $order_obj->billing_first_name : $order_obj->get_billing_first_name();
-    echo sprintf( __( 'Hello %s', 'quote-wc' ), $billing_first_name ) . "\n\n";
+    echo sprintf( __( 'Hello %s', 'quotes-for-woocommerce' ), $billing_first_name ) . "\n\n";
 endif;
 
-echo sprintf( __( 'You have received a quotation for your order on %s. The details of the same are shown below.', 'quote-wc' ), $order->blogname );
+echo sprintf( __( 'You have received a quotation for your order on %s. The details of the same are shown below.', 'quotes-for-woocommerce' ), $order->blogname );
 
 if ( $order_obj ) :
 
     $order_status = $order_obj->get_status(); 
 	if ( $order_status == 'pending' ) :
-        echo sprintf( __( 'To pay for this order please use the following link: %s', 'quote-wc' ), $order_obj->get_checkout_payment_url() );
+        echo sprintf( __( 'To pay for this order please use the following link: %s', 'quotes-for-woocommerce' ), $order_obj->get_checkout_payment_url() );
 	endif;
 
 	do_action( 'woocommerce_email_before_order_table', $order_obj, $sent_to_admin, $plain_text, $email );
@@ -30,8 +30,8 @@ if ( $order_obj ) :
         $post_date = strtotime ( $order_post->post_date );
         $order_date = date( 'Y-m-d H:i:s', $post_date );
     }
-    echo sprintf( __( 'Order number: %s', 'quote-wc'), $order_obj->get_order_number() ) . "\n";
-    echo sprintf( __( 'Order date: %s', 'quote-wc'), date_i18n( wc_date_format(), strtotime( $order_date ) ) ) . "\n";
+    echo sprintf( __( 'Order number: %s', 'quotes-for-woocommerce'), $order_obj->get_order_number() ) . "\n";
+    echo sprintf( __( 'Order date: %s', 'quotes-for-woocommerce'), date_i18n( wc_date_format(), strtotime( $order_date ) ) ) . "\n";
     
 	do_action( 'woocommerce_email_order_meta', $order_obj, $sent_to_admin, $plain_text );
 

--- a/quotes-for-woocommerce/templates/emails/request-new-quote.php
+++ b/quotes-for-woocommerce/templates/emails/request-new-quote.php
@@ -7,7 +7,7 @@
 
 $order_obj = new WC_order( $order->order_id );
 // translators: Billing Name.
-$opening_paragraph = __( 'A request for quote has been made by %s and is awaiting your attention. The details of the order are as follows:', 'quote-wc' );
+$opening_paragraph = __( 'A request for quote has been made by %s and is awaiting your attention. The details of the order are as follows:', 'quotes-for-woocommerce' );
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading ); ?>
@@ -23,9 +23,9 @@ if ( $order && $billing_first_name && $billing_last_name ) :
 <table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
 	<tbody>
 		<tr>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quote-wc' ); ?></th>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quote-wc' ); ?></th>
-			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product Price', 'quote-wc' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quotes-for-woocommerce' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quotes-for-woocommerce' ); ?></th>
+			<th style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product Price', 'quotes-for-woocommerce' ); ?></th>
 
 		</tr>
 		<?php
@@ -42,12 +42,12 @@ if ( $order && $billing_first_name && $billing_last_name ) :
 	</tbody>
 </table>
 
-<p><?php esc_html_e( 'This order is awaiting a quote.', 'quote-wc' ); ?></p>
+<p><?php esc_html_e( 'This order is awaiting a quote.', 'quotes-for-woocommerce' ); ?></p>
 
 <p>
 	<?php
 	// translators: Admin Url for payment.
-	echo wp_kses_post( make_clickable( sprintf( __( 'You can view and edit this order in the dashboard here: %s', 'quote-wc' ), esc_url( admin_url( 'post.php?post=' . $order->order_id . '&action=edit' ) ) ) ) );
+	echo wp_kses_post( make_clickable( sprintf( __( 'You can view and edit this order in the dashboard here: %s', 'quotes-for-woocommerce' ), esc_url( admin_url( 'post.php?post=' . $order->order_id . '&action=edit' ) ) ) ) );
 	?>
 </p>
 <?php do_action( 'woocommerce_email_customer_details', $order_obj, $sent_to_admin, $plain_text, $email ); ?>

--- a/quotes-for-woocommerce/templates/emails/send-quote.php
+++ b/quotes-for-woocommerce/templates/emails/send-quote.php
@@ -17,7 +17,7 @@ if ( $order_obj ) :
 	<p>
 		<?php
 		// translators: Billing First Name.
-		echo sprintf( esc_html__( 'Hello %s', 'quote-wc' ), esc_attr( $billing_first_name ) );
+		echo sprintf( esc_html__( 'Hello %s', 'quotes-for-woocommerce' ), esc_attr( $billing_first_name ) );
 		?>
 	</p>
 <?php endif; ?>
@@ -25,7 +25,7 @@ if ( $order_obj ) :
 <p>
 	<?php
 	// translators: Site Name.
-	echo sprintf( esc_html__( 'You have received a quotation for your order on %s. The details of the same are shown below.', 'quote-wc' ), esc_attr( $order->blogname ) );
+	echo sprintf( esc_html__( 'You have received a quotation for your order on %s. The details of the same are shown below.', 'quotes-for-woocommerce' ), esc_attr( $order->blogname ) );
 	?>
 </p>
 
@@ -38,7 +38,7 @@ if ( $order_obj ) :
 		<p>
 			<?php
 			// translators: Payment Link Url.
-			echo sprintf( esc_html__( 'To pay for this order please use the following link: %s', 'quote-wc' ), '<a href="' . esc_url( $order_obj->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for order', 'quote-wc' ) . '</a>' );
+			echo sprintf( esc_html__( 'To pay for this order please use the following link: %s', 'quotes-for-woocommerce' ), '<a href="' . esc_url( $order_obj->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for order', 'quotes-for-woocommerce' ) . '</a>' );
 			?>
 		</p>
 	<?php endif; ?>
@@ -54,13 +54,13 @@ if ( $order_obj ) :
 		$order_date = date( 'Y-m-d H:i:s', $post_date ); //phpcs:ignore
 	}
 	?>
-	<h2><?php echo esc_html__( 'Order', 'quote-wc' ) . ': ' . esc_html( $order_obj->get_order_number() ); ?> (<?php printf( '<time datetime="%s">%s</time>', date_i18n( 'c', strtotime( $order_date ) ), date_i18n( wc_date_format(), strtotime( $order_date ) ) ); // phpcs:ignore ?>)</h2>
+	<h2><?php echo esc_html__( 'Order', 'quotes-for-woocommerce' ) . ': ' . esc_html( $order_obj->get_order_number() ); ?> (<?php printf( '<time datetime="%s">%s</time>', date_i18n( 'c', strtotime( $order_date ) ), date_i18n( wc_date_format(), strtotime( $order_date ) ) ); // phpcs:ignore ?>)</h2>
 	<table cellspacing="0" cellpadding="6" style="width: 100%; border: 1px solid #eee;" border="1" bordercolor="#eee">
 		<thead>
 			<tr>
-				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quote-wc' ); ?></th>
-				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quote-wc' ); ?></th>
-				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Price', 'quote-wc' ); ?></th>
+				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Product', 'quotes-for-woocommerce' ); ?></th>
+				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Quantity', 'quotes-for-woocommerce' ); ?></th>
+				<th scope="col" style="text-align:left; border: 1px solid #eee;"><?php esc_html_e( 'Price', 'quotes-for-woocommerce' ); ?></th>
 			</tr>
 		</thead>
 		<tbody>


### PR DESCRIPTION
- Updated text domain in header comment and all the i18n functions with the plugin slug to enable the string detection in the core translation system (GlotPress).
- Generated new quotes-for-woocommerce.pot file.
- Removed the minor version in "Tested up to:" metadata. The repository will automatically add the latest minor version as plugins shouldn’t break with a minor update.
- Added the License and License URI in header comment and readme.txt. This metadata is mandatory for new plugins since April 2020.