### PR TITLE
Mini cart shows the price amount for quote products.

### DIFF
--- a/quotes-for-woocommerce/assets/css/qwc-shop.css
+++ b/quotes-for-woocommerce/assets/css/qwc-shop.css
@@ -1,3 +1,6 @@
 .site-header-cart .cart-contents .amount {
     display: none;
 }
+.top-cart .woocommerce-Price-amount {
+    display: none;
+}


### PR DESCRIPTION
The issue occurs with the trusted theme which can be found https://uxlthemes.com/theme/trusted/ reported by a client https://wordpress.org/support/topic/mini-cart-still-displays-cart-total/